### PR TITLE
Refresh theme with Facebook-inspired palette and night mode toggle

### DIFF
--- a/src/app/dashboard/analytics/page.js
+++ b/src/app/dashboard/analytics/page.js
@@ -125,7 +125,7 @@ export default function AnalyticsPage() {
     <div className="mx-auto flex w-full max-w-5xl flex-col space-y-8 px-4 sm:px-6">
       <header>
         <h1 className="text-3xl font-semibold">Analytics</h1>
-        <p className="mt-2 max-w-2xl text-sm text-neutral-400">
+        <p className="mt-2 max-w-2xl text-sm text-[var(--muted)]">
           Visualize how capital performs across strategies, timeframes, and
           qualitative tags. Replace the mocked data with Supabase materialized
           views or RPC calls to unlock production-grade insights.
@@ -136,14 +136,14 @@ export default function AnalyticsPage() {
         {summaryCards.map((card) => (
           <article
             key={card.label}
-            className="flex flex-col justify-between rounded-2xl border border-neutral-900 bg-neutral-950/70 p-6"
+            className="flex flex-col justify-between rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-lg"
           >
             <div>
-              <p className="text-xs font-medium uppercase tracking-wide text-neutral-500">
+              <p className="text-xs font-medium uppercase tracking-wide text-[var(--muted)]">
                 {card.label}
               </p>
-              <p className="mt-3 text-3xl font-semibold text-white">{card.value}</p>
-              <p className="mt-2 text-xs text-neutral-500">
+              <p className="mt-3 text-3xl font-semibold text-[var(--foreground)]">{card.value}</p>
+              <p className="mt-2 text-xs text-[var(--muted)]">
                 <span className={card.positive ? "text-emerald-400" : "text-rose-400"}>
                   {card.change}
                 </span>{" "}
@@ -167,19 +167,19 @@ export default function AnalyticsPage() {
         ))}
       </section>
 
-      <section className="rounded-2xl border border-neutral-900 bg-neutral-950/60 p-6">
+      <section className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-lg">
         <div className="flex flex-col gap-8 lg:flex-row">
           <div className="flex-1">
             <div className="flex items-center justify-between">
               <div>
-                <h2 className="text-lg font-medium text-white">Equity curve</h2>
-                <p className="text-sm text-neutral-500">Last 90 sessions</p>
+                <h2 className="text-lg font-medium text-[var(--foreground)]">Equity curve</h2>
+                <p className="text-sm text-[var(--muted)]">Last 90 sessions</p>
               </div>
-              <span className="rounded-full border border-white/10 px-3 py-1 text-xs text-neutral-300">
+              <span className="rounded-full border border-[var(--border)] bg-[var(--surface-hover)] px-3 py-1 text-xs text-[var(--muted)]">
                 Simulated data
               </span>
             </div>
-            <div className="mt-6 flex h-48 items-end gap-2 rounded-2xl border border-neutral-900 bg-neutral-950/80 p-4">
+            <div className="mt-6 flex h-48 items-end gap-2 rounded-2xl border border-[var(--border)] bg-[var(--surface-muted)] p-4">
               {equityCurve.map((point, index) => (
                 <span
                   key={`equity-${index}`}
@@ -190,21 +190,21 @@ export default function AnalyticsPage() {
             </div>
           </div>
 
-          <div className="w-full max-w-sm rounded-2xl border border-neutral-900 bg-neutral-950/80 p-6">
-            <h3 className="text-sm font-medium uppercase tracking-wide text-neutral-400">
+          <div className="w-full max-w-sm rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6">
+            <h3 className="text-sm font-medium uppercase tracking-wide text-[var(--muted)]">
               Streak insights
             </h3>
             <dl className="mt-4 grid grid-cols-2 gap-4 text-sm">
               {streakMetrics.map((item) => (
                 <div key={item.label}>
-                  <dt className="text-neutral-500">{item.label}</dt>
-                  <dd className="mt-1 text-base font-semibold text-white">
+                  <dt className="text-[var(--muted)]">{item.label}</dt>
+                  <dd className="mt-1 text-base font-semibold text-[var(--foreground)]">
                     {item.value}
                   </dd>
                 </div>
               ))}
             </dl>
-            <div className="mt-6 space-y-3 text-xs text-neutral-400">
+            <div className="mt-6 space-y-3 text-xs text-[var(--muted)]">
               <p>
                 Use streak data to adapt sizing rules. For example, throttle risk
                 after two losses and scale back in on a three-day green run.
@@ -220,19 +220,19 @@ export default function AnalyticsPage() {
       </section>
 
       <section className="grid gap-4 lg:grid-cols-3">
-        <article className="lg:col-span-2 rounded-2xl border border-neutral-900 bg-neutral-950/60">
-          <header className="flex items-center justify-between border-b border-neutral-900 px-6 py-4">
+        <article className="lg:col-span-2 rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-lg">
+          <header className="flex items-center justify-between border-b border-[var(--border)] px-6 py-4">
             <div>
-              <h2 className="text-lg font-medium text-white">Strategy performance</h2>
-              <p className="text-sm text-neutral-500">
+              <h2 className="text-lg font-medium text-[var(--foreground)]">Strategy performance</h2>
+              <p className="text-sm text-[var(--muted)]">
                 Merge trade records with strategy metadata to surface winners.
               </p>
             </div>
-            <span className="text-xs text-neutral-500">Mocked sample</span>
+            <span className="text-xs text-[var(--muted)]">Mocked sample</span>
           </header>
           <div className="overflow-x-auto px-6 py-4">
             <table className="min-w-full text-left text-sm">
-              <thead className="text-neutral-500">
+              <thead className="text-[var(--muted)]">
                 <tr>
                   <th className="py-2 pr-6 font-medium">Strategy</th>
                   <th className="py-2 pr-6 font-medium">Trades</th>
@@ -242,17 +242,17 @@ export default function AnalyticsPage() {
                   <th className="py-2 font-medium">Impact</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-neutral-900">
+              <tbody className="divide-y divide-[var(--border)]">
                 {strategyMetrics.map((strategy) => (
-                  <tr key={strategy.name} className="text-neutral-300">
-                    <td className="py-3 pr-6 text-white">{strategy.name}</td>
+                  <tr key={strategy.name} className="text-[var(--muted)]">
+                    <td className="py-3 pr-6 text-[var(--foreground)]">{strategy.name}</td>
                     <td className="py-3 pr-6">{strategy.trades}</td>
                     <td className="py-3 pr-6">{strategy.winRate}%</td>
                     <td className="py-3 pr-6">{strategy.expectancy}</td>
                     <td className="py-3 pr-6">{strategy.pnl}</td>
                     <td className="py-3">
                       <div className="flex items-center gap-3">
-                        <div className="h-2 flex-1 rounded-full bg-white/10">
+                        <div className="h-2 flex-1 rounded-full bg-[var(--surface-hover)]">
                           <div
                             className={`h-2 rounded-full ${
                               strategy.pnl.startsWith("-")
@@ -262,7 +262,7 @@ export default function AnalyticsPage() {
                             style={{ width: `${Math.min(Math.abs(strategy.winRate), 100)}%` }}
                           />
                         </div>
-                        <span className="text-xs text-neutral-400">
+                        <span className="text-xs text-[var(--muted)]">
                           {strategy.impact}
                         </span>
                       </div>
@@ -274,19 +274,19 @@ export default function AnalyticsPage() {
           </div>
         </article>
 
-        <aside className="rounded-2xl border border-neutral-900 bg-neutral-950/60 p-6">
-          <h2 className="text-lg font-medium text-white">Timeframe mix</h2>
-          <p className="mt-1 text-sm text-neutral-500">
+        <aside className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-lg">
+          <h2 className="text-lg font-medium text-[var(--foreground)]">Timeframe mix</h2>
+          <p className="mt-1 text-sm text-[var(--muted)]">
             Monitor position duration trends to balance risk across regimes.
           </p>
-          <ul className="mt-6 space-y-4 text-sm text-neutral-300">
+          <ul className="mt-6 space-y-4 text-sm text-[var(--muted)]">
             {timeframeDistribution.map((bucket) => (
               <li key={bucket.label}>
-                <div className="flex items-center justify-between text-xs uppercase tracking-wide text-neutral-500">
+                <div className="flex items-center justify-between text-xs uppercase tracking-wide text-[var(--muted)]">
                   <span>{bucket.label}</span>
                   <span>{bucket.value}%</span>
                 </div>
-                <div className="mt-2 h-2 rounded-full bg-white/10">
+                <div className="mt-2 h-2 rounded-full bg-[var(--surface-hover)]">
                   <div
                     className="h-2 rounded-full bg-gradient-to-r from-sky-500/60 via-sky-500 to-sky-400"
                     style={{ width: `${bucket.value}%` }}
@@ -299,31 +299,31 @@ export default function AnalyticsPage() {
       </section>
 
       <section className="grid gap-4 md:grid-cols-2">
-        <article className="rounded-2xl border border-neutral-900 bg-neutral-950/60 p-6">
-          <h2 className="text-lg font-medium text-white">Tag performance</h2>
-          <p className="mt-1 text-sm text-neutral-500">
+        <article className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-lg">
+          <h2 className="text-lg font-medium text-[var(--foreground)]">Tag performance</h2>
+          <p className="mt-1 text-sm text-[var(--muted)]">
             Bring qualitative tags into analytics to spot drift early.
           </p>
           <div className="mt-6 space-y-4">
             {tagPerformance.map((item) => (
               <div
                 key={item.tag}
-                className="rounded-xl border border-neutral-900 bg-neutral-950/80 p-4"
+                className="rounded-xl border border-[var(--border)] bg-[var(--surface-muted)] p-4"
               >
                 <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-white">{item.tag}</span>
-                  <span className="text-xs text-neutral-400">{item.pnl}</span>
+                  <span className="text-sm font-medium text-[var(--foreground)]">{item.tag}</span>
+                  <span className="text-xs text-[var(--muted)]">{item.pnl}</span>
                 </div>
-                <dl className="mt-3 grid grid-cols-2 gap-3 text-xs text-neutral-400">
+                <dl className="mt-3 grid grid-cols-2 gap-3 text-xs text-[var(--muted)]">
                   <div>
                     <dt>Win rate</dt>
-                    <dd className="mt-1 text-sm font-semibold text-white">
+                    <dd className="mt-1 text-sm font-semibold text-[var(--foreground)]">
                       {item.winRate}%
                     </dd>
                   </div>
                   <div>
                     <dt>Average R</dt>
-                    <dd className="mt-1 text-sm font-semibold text-white">
+                    <dd className="mt-1 text-sm font-semibold text-[var(--foreground)]">
                       {item.avgR}R
                     </dd>
                   </div>
@@ -333,20 +333,20 @@ export default function AnalyticsPage() {
           </div>
         </article>
 
-        <article className="rounded-2xl border border-dashed border-neutral-800 bg-neutral-950/50 p-6">
-          <h2 className="text-lg font-medium text-white">Review queue</h2>
-          <p className="mt-1 text-sm text-neutral-500">
+        <article className="rounded-2xl border border-dashed border-[var(--border)] bg-[var(--surface-muted)] p-6">
+          <h2 className="text-lg font-medium text-[var(--foreground)]">Review queue</h2>
+          <p className="mt-1 text-sm text-[var(--muted)]">
             Translate analytics into deliberate practice with weekly rituals.
           </p>
-          <ul className="mt-6 space-y-4 text-sm text-neutral-300">
+          <ul className="mt-6 space-y-4 text-sm text-[var(--muted)]">
             {reviewPipeline.map((item) => (
-              <li key={item.title} className="rounded-xl border border-neutral-900 bg-neutral-950/80 p-4">
-                <p className="font-medium text-white">{item.title}</p>
-                <p className="mt-2 text-xs text-neutral-400">{item.description}</p>
+              <li key={item.title} className="rounded-xl border border-[var(--border)] bg-[var(--surface-muted)] p-4">
+                <p className="font-medium text-[var(--foreground)]">{item.title}</p>
+                <p className="mt-2 text-xs text-[var(--muted)]">{item.description}</p>
               </li>
             ))}
           </ul>
-          <p className="mt-6 text-xs text-neutral-500">
+          <p className="mt-6 text-xs text-[var(--muted)]">
             Wire this list to Supabase task tables or Notion exports to keep your
             review cadence tight.
           </p>

--- a/src/app/dashboard/journal/page.js
+++ b/src/app/dashboard/journal/page.js
@@ -130,7 +130,7 @@ export default function JournalPage() {
     <div className="mx-auto flex w-full max-w-5xl flex-col space-y-8 px-4 sm:px-6">
       <header>
         <h1 className="text-3xl font-semibold">Journal</h1>
-        <p className="mt-2 max-w-2xl text-sm text-neutral-400">
+        <p className="mt-2 max-w-2xl text-sm text-[var(--muted)]">
           Keep qualitative notes, link them to trades, and set follow-up prompts.
           The next iteration introduces the editor, trade linking, and reminder
           workflows.
@@ -141,13 +141,13 @@ export default function JournalPage() {
         {highlightCards.map((card) => (
           <article
             key={card.title}
-            className="flex flex-col justify-between rounded-2xl border border-neutral-900 bg-neutral-950/70 p-6"
+            className="flex flex-col justify-between rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-lg"
           >
             <div>
-              <p className="text-xs font-medium uppercase tracking-wide text-neutral-500">
+              <p className="text-xs font-medium uppercase tracking-wide text-[var(--muted)]">
                 {card.title}
               </p>
-              <p className="mt-3 text-sm text-neutral-300">{card.insight}</p>
+              <p className="mt-3 text-sm text-[var(--muted)]">{card.insight}</p>
             </div>
             <span
               className={`mt-6 inline-flex w-max items-center rounded-full px-3 py-1 text-xs font-medium ${
@@ -165,17 +165,17 @@ export default function JournalPage() {
       </section>
 
       <section className="grid gap-6 lg:grid-cols-3">
-        <article className="lg:col-span-2 rounded-2xl border border-neutral-900 bg-neutral-950/70 p-6">
+        <article className="lg:col-span-2 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-lg">
           <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <h2 className="text-lg font-medium text-white">Quick capture</h2>
-              <p className="text-sm text-neutral-500">
+              <h2 className="text-lg font-medium text-[var(--foreground)]">Quick capture</h2>
+              <p className="text-sm text-[var(--muted)]">
                 Draft thoughts here before promoting them to a structured entry.
               </p>
             </div>
             <button
               type="button"
-              className="inline-flex items-center justify-center rounded-full border border-white/10 px-4 py-1.5 text-sm font-medium text-white shadow-sm transition hover:bg-white/10"
+              className="inline-flex items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface)] px-4 py-1.5 text-sm font-medium text-[var(--foreground)] shadow-sm transition hover:bg-[var(--surface-hover)]"
             >
               Start new entry
             </button>
@@ -185,38 +185,38 @@ export default function JournalPage() {
               rows={4}
               readOnly
               placeholder="What stood out from today's session?"
-              className="w-full rounded-xl border border-neutral-800 bg-neutral-950/80 px-4 py-3 text-sm text-neutral-200 placeholder:text-neutral-600 focus:border-neutral-700 focus:outline-none"
+              className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-muted)] px-4 py-3 text-sm text-[var(--foreground)] placeholder:text-[color:var(--muted)] focus:border-[color:rgba(24,119,242,0.35)] focus:outline-none"
             />
             <div className="grid gap-4 sm:grid-cols-2">
               {quickCapturePrompts.map((prompt) => (
                 <div
                   key={prompt.label}
-                  className="rounded-xl border border-dashed border-neutral-800 bg-neutral-950/60 p-4"
+                  className="rounded-xl border border-dashed border-[var(--border)] bg-[var(--surface-muted)] p-4"
                 >
-                  <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">
                     {prompt.label}
                   </p>
-                  <p className="mt-2 text-sm text-neutral-300">{prompt.description}</p>
+                  <p className="mt-2 text-sm text-[var(--muted)]">{prompt.description}</p>
                 </div>
               ))}
             </div>
           </div>
         </article>
 
-        <article className="rounded-2xl border border-neutral-900 bg-neutral-950/70 p-6">
-          <h2 className="text-lg font-medium text-white">Review queue</h2>
-          <p className="mt-1 text-sm text-neutral-500">
+        <article className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-lg">
+          <h2 className="text-lg font-medium text-[var(--foreground)]">Review queue</h2>
+          <p className="mt-1 text-sm text-[var(--muted)]">
             Upcoming follow-ups and deep work sessions sourced from entries.
           </p>
           <ul className="mt-4 space-y-4 text-sm">
             {reviewQueue.map((item) => (
               <li
                 key={item.title}
-                className="rounded-xl border border-neutral-900 bg-neutral-950/80 p-4"
+                className="rounded-xl border border-[var(--border)] bg-[var(--surface-muted)] p-4"
               >
-                <p className="font-medium text-white">{item.title}</p>
-                <p className="mt-1 text-neutral-400">{item.description}</p>
-                <p className="mt-3 text-xs uppercase tracking-wide text-neutral-500">
+                <p className="font-medium text-[var(--foreground)]">{item.title}</p>
+                <p className="mt-1 text-[var(--muted)]">{item.description}</p>
+                <p className="mt-3 text-xs uppercase tracking-wide text-[var(--muted)]">
                   {item.due}
                 </p>
               </li>
@@ -225,15 +225,15 @@ export default function JournalPage() {
         </article>
       </section>
 
-      <section className="rounded-2xl border border-neutral-900 bg-neutral-950/70 p-6">
+      <section className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-lg">
         <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h2 className="text-lg font-medium text-white">Recent entries</h2>
-            <p className="text-sm text-neutral-500">
+            <h2 className="text-lg font-medium text-[var(--foreground)]">Recent entries</h2>
+            <p className="text-sm text-[var(--muted)]">
               Timeline of reflections linked to trades and next steps.
             </p>
           </div>
-          <span className="inline-flex items-center rounded-full border border-white/10 px-3 py-1 text-xs text-neutral-300">
+          <span className="inline-flex items-center rounded-full border border-[var(--border)] bg-[var(--surface-hover)] px-3 py-1 text-xs text-[var(--muted)]">
             Syncing from Supabase soon
           </span>
         </header>
@@ -241,57 +241,57 @@ export default function JournalPage() {
           {journalEntries.map((entry) => (
             <li
               key={entry.id}
-              className="rounded-2xl border border-neutral-900 bg-neutral-950/80 p-6"
+              className="rounded-2xl border border-[var(--border)] bg-[var(--surface-muted)] p-6"
             >
               <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                 <div>
-                  <p className="text-xs uppercase tracking-wide text-neutral-500">
+                  <p className="text-xs uppercase tracking-wide text-[var(--muted)]">
                     {entry.timestamp}
                   </p>
-                  <h3 className="mt-1 text-xl font-semibold text-white">
+                  <h3 className="mt-1 text-xl font-semibold text-[var(--foreground)]">
                     {entry.title}
                   </h3>
-                  <p className="text-sm text-neutral-500">{entry.tradeRef}</p>
+                  <p className="text-sm text-[var(--muted)]">{entry.tradeRef}</p>
                 </div>
-                <span className="inline-flex w-max rounded-full border border-white/10 px-3 py-1 text-xs text-neutral-300">
+                <span className="inline-flex w-max rounded-full border border-[var(--border)] bg-[var(--surface-hover)] px-3 py-1 text-xs text-[var(--muted)]">
                   {entry.sentiment}
                 </span>
               </div>
-              <p className="mt-4 text-sm leading-relaxed text-neutral-300">
+              <p className="mt-4 text-sm leading-relaxed text-[var(--muted)]">
                 {entry.summary}
               </p>
               <ul className="mt-4 flex flex-wrap gap-2">
                 {entry.tags.map((tag) => (
                   <li
                     key={`${entry.id}-${tag}`}
-                    className="rounded-full bg-white/10 px-3 py-1 text-xs text-white"
+                    className="rounded-full bg-[color:rgba(24,119,242,0.12)] px-3 py-1 text-xs font-medium text-[var(--primary)]"
                   >
                     {tag}
                   </li>
                 ))}
               </ul>
-              <div className="mt-4 space-y-2 text-sm text-neutral-300">
+              <div className="mt-4 space-y-2 text-sm text-[var(--muted)]">
                 {entry.takeaways.map((item, index) => (
                   <p key={`${entry.id}-takeaway-${index}`} className="flex gap-2">
-                    <span className="text-neutral-500">•</span>
+                    <span className="text-[var(--muted)]">•</span>
                     <span>{item}</span>
                   </p>
                 ))}
               </div>
-              <div className="mt-4 rounded-xl border border-dashed border-neutral-800 bg-neutral-950/70 p-4 text-sm text-neutral-400">
-                <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+              <div className="mt-4 rounded-xl border border-dashed border-[var(--border)] bg-[var(--surface)] p-4 text-sm text-[var(--muted)]">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">
                   Follow-up
                 </p>
-                <p className="mt-1 text-neutral-300">{entry.followUp}</p>
+                <p className="mt-1 text-[var(--muted)]">{entry.followUp}</p>
               </div>
             </li>
           ))}
         </ol>
       </section>
 
-      <section className="rounded-2xl border border-neutral-900 bg-neutral-950/70 p-6">
-        <h2 className="text-lg font-medium text-white">Saved templates</h2>
-        <p className="mt-1 text-sm text-neutral-500">
+      <section className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-lg">
+        <h2 className="text-lg font-medium text-[var(--foreground)]">Saved templates</h2>
+        <p className="mt-1 text-sm text-[var(--muted)]">
           Build structured reflections you can reuse. Attach them to sessions
           and strategies to compare progress over time.
         </p>
@@ -299,11 +299,11 @@ export default function JournalPage() {
           {templates.map((template) => (
             <article
               key={template.name}
-              className="rounded-2xl border border-neutral-900 bg-neutral-950/80 p-5"
+              className="rounded-2xl border border-[var(--border)] bg-[var(--surface-muted)] p-5"
             >
-              <p className="text-sm font-medium text-white">{template.name}</p>
-              <p className="mt-2 text-sm text-neutral-400">{template.description}</p>
-              <p className="mt-4 text-xs uppercase tracking-wide text-neutral-500">
+              <p className="text-sm font-medium text-[var(--foreground)]">{template.name}</p>
+              <p className="mt-2 text-sm text-[var(--muted)]">{template.description}</p>
+              <p className="mt-4 text-xs uppercase tracking-wide text-[var(--muted)]">
                 {template.cadence}
               </p>
             </article>

--- a/src/app/dashboard/settings/page.js
+++ b/src/app/dashboard/settings/page.js
@@ -3,16 +3,16 @@ export default function SettingsPage() {
     <div className="mx-auto flex w-full max-w-5xl flex-col space-y-8 px-4 sm:px-6">
       <header>
         <h1 className="text-3xl font-semibold">Settings</h1>
-        <p className="mt-2 max-w-2xl text-sm text-neutral-400">
+        <p className="mt-2 max-w-2xl text-sm text-[var(--muted)]">
           Manage workspace defaults, notification preferences, and PWA install
           guidance. This page will also surface broker integrations and data
           export tools as they land.
         </p>
       </header>
 
-      <div className="rounded-2xl border border-dashed border-neutral-800 bg-neutral-950/50 p-6">
-        <h2 className="text-lg font-medium">Next build steps</h2>
-        <ul className="mt-3 list-disc space-y-1 pl-6 text-sm text-neutral-400">
+      <div className="rounded-2xl border border-dashed border-[var(--border)] bg-[var(--surface-muted)] p-6">
+        <h2 className="text-lg font-medium text-[var(--foreground)]">Next build steps</h2>
+        <ul className="mt-3 list-disc space-y-1 pl-6 text-sm text-[var(--muted)]">
           <li>Workspace defaults: timezone, base currency, lot sizing rules.</li>
           <li>Notification channels (email, push) and reminder cadence.</li>
           <li>Manage API keys, exports, and team member invites.</li>

--- a/src/app/dashboard/trades/page.js
+++ b/src/app/dashboard/trades/page.js
@@ -27,7 +27,7 @@ export default async function TradesPage() {
     <div className="mx-auto flex w-full max-w-5xl flex-col space-y-8 px-4 sm:px-6">
       <header>
         <h1 className="text-3xl font-semibold">Trades</h1>
-        <p className="mt-2 max-w-2xl text-sm text-neutral-400">
+        <p className="mt-2 max-w-2xl text-sm text-[var(--muted)]">
           Review your most recent executions. The next iteration will add inline
           editing, advanced filters, and rich media attachments.
         </p>
@@ -35,10 +35,10 @@ export default async function TradesPage() {
 
       <TradeForm />
 
-      <div className="rounded-2xl border border-neutral-900 bg-neutral-950/60">
-        <div className="border-b border-neutral-900 px-6 py-4">
-          <h2 className="text-lg font-medium">Recent trades</h2>
-          <p className="text-sm text-neutral-500">
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-lg">
+        <div className="border-b border-[var(--border)] px-6 py-4">
+          <h2 className="text-lg font-medium text-[var(--foreground)]">Recent trades</h2>
+          <p className="text-sm text-[var(--muted)]">
             Data loads directly from Supabase with Row Level Security enforcing
             per-user access.
           </p>
@@ -49,89 +49,89 @@ export default async function TradesPage() {
             {fetchError}
           </div>
         ) : trades.length === 0 ? (
-          <div className="px-6 py-10 text-sm text-neutral-400">
+          <div className="px-6 py-10 text-sm text-[var(--muted)]">
             No trades logged yet. Once you connect the entry form, new trades
             will surface here immediately.
           </div>
         ) : (
           <>
             <div className="hidden overflow-x-auto md:block">
-              <table className="min-w-full divide-y divide-neutral-900 text-sm">
-                <thead className="bg-neutral-950/80">
-                <tr className="text-left text-neutral-500">
-                  <th className="px-6 py-3 font-medium">Symbol</th>
-                  <th className="px-6 py-3 font-medium">Side</th>
-                  <th className="px-6 py-3 font-medium">Qty</th>
-                  <th className="px-6 py-3 font-medium">Entry</th>
-                  <th className="px-6 py-3 font-medium">Exit</th>
-                  <th className="px-6 py-3 font-medium">P/L</th>
-                  <th className="px-6 py-3 font-medium">P/L %</th>
-                  <th className="px-6 py-3 font-medium">Executed</th>
-                  <th className="px-6 py-3 font-medium">Status</th>
-                  <th className="px-6 py-3 font-medium">Tags</th>
-                  <th className="px-6 py-3 font-medium">Actions</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-neutral-900">
-                {trades.map((trade) => (
-                  <tr key={trade.id} className="hover:bg-white/5">
-                    <td className="px-6 py-3 font-medium text-white">
-                      {trade.symbol}
-                    </td>
-                    <td className="px-6 py-3 capitalize text-neutral-300">
-                      {trade.side}
-                    </td>
-                    <td className="px-6 py-3 text-neutral-300">
-                      {formatNumber(trade.quantity, { digits: 2 })}
-                    </td>
-                    <td className="px-6 py-3 text-neutral-300">
-                      {formatNumber(trade.entry_price, { digits: 4 })}
-                    </td>
-                    <td className="px-6 py-3 text-neutral-300">
-                      {formatNumber(trade.exit_price, { digits: 4 })}
-                    </td>
-                    <td className="px-6 py-3 text-neutral-300">
-                      {formatSignedNumber(calculateProfitValue(trade))}
-                    </td>
-                    <td className="px-6 py-3 text-neutral-300">
-                      {formatSignedPercentage(calculateProfitPercentage(trade))}
-                    </td>
-                    <td className="px-6 py-3 text-neutral-300">
-                      {formatDate(trade.executed_at)}
-                    </td>
-                    <td className="px-6 py-3 text-neutral-300">
-                      {formatStatus(trade.status)}
-                    </td>
-                    <td className="px-6 py-3 text-neutral-300">
-                      <div className="flex flex-wrap gap-1">
-                        {trade.trade_tags?.length
-                          ? trade.trade_tags.map((item) => (
-                              <span
-                                key={`${trade.id}-${item.tags?.id}`}
-                                className="rounded-full bg-white/10 px-2 py-1 text-xs text-white"
-                              >
-                                {item.tags?.name ?? "Tag"}
-                              </span>
-                            ))
-                          : DASH}
-                      </div>
-                    </td>
-                    <td className="px-6 py-3 text-neutral-300">
-                      <TradeRowActions trade={trade} />
-                    </td>
+              <table className="min-w-full divide-y divide-[var(--border)] text-sm">
+                <thead className="bg-[var(--surface-elevated)]">
+                  <tr className="text-left text-[var(--muted)]">
+                    <th className="px-6 py-3 font-medium">Symbol</th>
+                    <th className="px-6 py-3 font-medium">Side</th>
+                    <th className="px-6 py-3 font-medium">Qty</th>
+                    <th className="px-6 py-3 font-medium">Entry</th>
+                    <th className="px-6 py-3 font-medium">Exit</th>
+                    <th className="px-6 py-3 font-medium">P/L</th>
+                    <th className="px-6 py-3 font-medium">P/L %</th>
+                    <th className="px-6 py-3 font-medium">Executed</th>
+                    <th className="px-6 py-3 font-medium">Status</th>
+                    <th className="px-6 py-3 font-medium">Tags</th>
+                    <th className="px-6 py-3 font-medium">Actions</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="divide-y divide-[var(--border)]">
+                  {trades.map((trade) => (
+                    <tr key={trade.id} className="transition hover:bg-[var(--surface-hover)]">
+                      <td className="px-6 py-3 font-medium text-[var(--foreground)]">
+                        {trade.symbol}
+                      </td>
+                      <td className="px-6 py-3 capitalize text-[var(--muted)]">
+                        {trade.side}
+                      </td>
+                      <td className="px-6 py-3 text-[var(--muted)]">
+                        {formatNumber(trade.quantity, { digits: 2 })}
+                      </td>
+                      <td className="px-6 py-3 text-[var(--muted)]">
+                        {formatNumber(trade.entry_price, { digits: 4 })}
+                      </td>
+                      <td className="px-6 py-3 text-[var(--muted)]">
+                        {formatNumber(trade.exit_price, { digits: 4 })}
+                      </td>
+                      <td className="px-6 py-3 text-[var(--muted)]">
+                        {formatSignedNumber(calculateProfitValue(trade))}
+                      </td>
+                      <td className="px-6 py-3 text-[var(--muted)]">
+                        {formatSignedPercentage(calculateProfitPercentage(trade))}
+                      </td>
+                      <td className="px-6 py-3 text-[var(--muted)]">
+                        {formatDate(trade.executed_at)}
+                      </td>
+                      <td className="px-6 py-3 text-[var(--muted)]">
+                        {formatStatus(trade.status)}
+                      </td>
+                      <td className="px-6 py-3 text-[var(--muted)]">
+                        <div className="flex flex-wrap gap-1">
+                          {trade.trade_tags?.length
+                            ? trade.trade_tags.map((item) => (
+                                <span
+                                  key={`${trade.id}-${item.tags?.id}`}
+                                  className="rounded-full bg-[color:rgba(24,119,242,0.12)] px-2 py-1 text-xs font-medium text-[var(--primary)]"
+                                >
+                                  {item.tags?.name ?? "Tag"}
+                                </span>
+                              ))
+                            : DASH}
+                        </div>
+                      </td>
+                      <td className="px-6 py-3 text-[var(--muted)]">
+                        <TradeRowActions trade={trade} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
             <TradeCardList trades={trades} />
           </>
         )}
       </div>
 
-      <div className="rounded-2xl border border-dashed border-neutral-800 bg-neutral-950/50 p-6">
-        <h2 className="text-lg font-medium">Next build steps</h2>
-        <ul className="mt-3 list-disc space-y-1 pl-6 text-sm text-neutral-400">
+      <div className="rounded-2xl border border-dashed border-[var(--border)] bg-[var(--surface-muted)] p-6">
+        <h2 className="text-lg font-medium text-[var(--foreground)]">Next build steps</h2>
+        <ul className="mt-3 list-disc space-y-1 pl-6 text-sm text-[var(--muted)]">
           <li>Server actions for creating/updating trades with optimistic UI.</li>
           <li>Filter toolbar (dates, strategy, tags) and saved views.</li>
           <li>Attachment gallery powered by Supabase Storage.</li>

--- a/src/app/dashboard/trades/trade-card-list.js
+++ b/src/app/dashboard/trades/trade-card-list.js
@@ -56,7 +56,7 @@ function TradeCard({ trade }) {
       </div>
 
       <article
-        className="rounded-2xl border border-neutral-900 bg-neutral-950/80 p-5 shadow-sm transition-transform"
+        className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-5 shadow-sm transition-transform"
         style={{ transform: `translateX(${-offset}px)` }}
         onMouseDown={handleStart}
         onMouseMove={handleMove}
@@ -69,52 +69,52 @@ function TradeCard({ trade }) {
       >
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <p className="text-sm uppercase tracking-[0.2em] text-neutral-500">Symbol</p>
-            <p className="text-xl font-semibold text-white">{trade.symbol}</p>
+            <p className="text-sm uppercase tracking-[0.2em] text-[var(--muted)]">Symbol</p>
+            <p className="text-xl font-semibold text-[var(--foreground)]">{trade.symbol}</p>
           </div>
-          <span className="rounded-full border border-neutral-800 px-3 py-1 text-xs font-medium uppercase tracking-wide text-neutral-300">
+          <span className="rounded-full border border-[var(--border)] px-3 py-1 text-xs font-medium uppercase tracking-wide text-[var(--muted)]">
             {trade.side}
           </span>
         </div>
 
-        <dl className="mt-4 grid grid-cols-1 gap-4 text-sm text-neutral-300 sm:grid-cols-2">
+        <dl className="mt-4 grid grid-cols-1 gap-4 text-sm text-[var(--muted)] sm:grid-cols-2">
           <div>
-            <dt className="text-neutral-500">Quantity</dt>
-            <dd className="mt-1 font-medium text-white">{formatNumber(trade.quantity, { digits: 2 })}</dd>
+            <dt className="text-[var(--muted)]">Quantity</dt>
+            <dd className="mt-1 font-medium text-[var(--foreground)]">{formatNumber(trade.quantity, { digits: 2 })}</dd>
           </div>
           <div>
-            <dt className="text-neutral-500">Executed</dt>
+            <dt className="text-[var(--muted)]">Executed</dt>
             <dd className="mt-1">{formatDate(trade.executed_at)}</dd>
           </div>
           <div>
-            <dt className="text-neutral-500">Entry</dt>
+            <dt className="text-[var(--muted)]">Entry</dt>
             <dd className="mt-1">{formatNumber(trade.entry_price, { digits: 4 })}</dd>
           </div>
           <div>
-            <dt className="text-neutral-500">Exit</dt>
+            <dt className="text-[var(--muted)]">Exit</dt>
             <dd className="mt-1">{formatNumber(trade.exit_price, { digits: 4 })}</dd>
           </div>
           <div>
-            <dt className="text-neutral-500">P/L</dt>
+            <dt className="text-[var(--muted)]">P/L</dt>
             <dd className="mt-1 font-medium">{formatSignedNumber(calculateProfitValue(trade))}</dd>
           </div>
           <div>
-            <dt className="text-neutral-500">P/L %</dt>
+            <dt className="text-[var(--muted)]">P/L %</dt>
             <dd className="mt-1 font-medium">{formatSignedPercentage(calculateProfitPercentage(trade))}</dd>
           </div>
           <div className="col-span-2">
-            <dt className="text-neutral-500">Status</dt>
+            <dt className="text-[var(--muted)]">Status</dt>
             <dd className="mt-1">{formatStatus(trade.status)}</dd>
           </div>
           <div className="col-span-2">
-            <dt className="text-neutral-500">Tags</dt>
+            <dt className="text-[var(--muted)]">Tags</dt>
             <dd className="mt-1">
               <div className="flex flex-wrap gap-2">
                 {trade.trade_tags?.length
                   ? trade.trade_tags.map((item) => (
                       <span
                         key={`${trade.id}-${item.tags?.id}`}
-                        className="rounded-full bg-white/10 px-2 py-1 text-xs text-white"
+                        className="rounded-full bg-[color:rgba(24,119,242,0.12)] px-2 py-1 text-xs font-medium text-[var(--primary)]"
                       >
                         {item.tags?.name ?? "Tag"}
                       </span>

--- a/src/app/dashboard/trades/trade-edit-form.js
+++ b/src/app/dashboard/trades/trade-edit-form.js
@@ -11,7 +11,7 @@ const initialState = {
 };
 
 const inputClass =
-  "w-full rounded-lg border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm text-white placeholder-neutral-600 focus:outline-none focus:ring-2 focus:ring-white/20";
+  "w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--foreground)] placeholder:text-[color:var(--muted)] focus:outline-none focus:ring-2 focus:ring-[color:rgba(24,119,242,0.35)]";
 
 function SubmitButton() {
   const { pending } = useFormStatus();
@@ -20,7 +20,7 @@ function SubmitButton() {
     <button
       type="submit"
       disabled={pending}
-      className="inline-flex items-center justify-center rounded-lg bg-white px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:bg-neutral-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white disabled:cursor-not-allowed disabled:opacity-70"
+      className="inline-flex items-center justify-center rounded-lg bg-[var(--primary)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[var(--primary-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)] disabled:cursor-not-allowed disabled:opacity-70"
     >
       {pending ? "Saving…" : "Save changes"}
     </button>
@@ -70,8 +70,8 @@ export default function TradeEditForm({ trade, onClose }) {
   return (
     <div className="flex flex-col gap-6">
       <header className="space-y-1">
-        <h3 className="text-lg font-semibold text-white">Edit trade</h3>
-        <p className="text-sm text-neutral-500">
+        <h3 className="text-lg font-semibold text-[var(--foreground)]">Edit trade</h3>
+        <p className="text-sm text-[var(--muted)]">
           Update execution details below. Fees recalculate automatically from entry and exit.
         </p>
       </header>
@@ -83,7 +83,7 @@ export default function TradeEditForm({ trade, onClose }) {
 
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-2">
-            <label className="text-sm font-medium text-white">Symbol</label>
+            <label className="text-sm font-medium text-[var(--foreground)]">Symbol</label>
             <input
               name="symbol"
               defaultValue={trade.symbol}
@@ -94,7 +94,7 @@ export default function TradeEditForm({ trade, onClose }) {
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-white">Side</label>
+            <label className="text-sm font-medium text-[var(--foreground)]">Side</label>
             <select
               name="side"
               defaultValue={trade.side}
@@ -106,7 +106,7 @@ export default function TradeEditForm({ trade, onClose }) {
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-white">Quantity</label>
+            <label className="text-sm font-medium text-[var(--foreground)]">Quantity</label>
             <input
               name="quantity"
               type="number"
@@ -119,7 +119,7 @@ export default function TradeEditForm({ trade, onClose }) {
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-white">Status</label>
+            <label className="text-sm font-medium text-[var(--foreground)]">Status</label>
             <select
               name="status"
               defaultValue={trade.status}
@@ -133,7 +133,7 @@ export default function TradeEditForm({ trade, onClose }) {
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-white">Entry price</label>
+            <label className="text-sm font-medium text-[var(--foreground)]">Entry price</label>
             <input
               name="entryPrice"
               type="number"
@@ -145,7 +145,7 @@ export default function TradeEditForm({ trade, onClose }) {
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-white">Exit price</label>
+            <label className="text-sm font-medium text-[var(--foreground)]">Exit price</label>
             <input
               name="exitPrice"
               type="number"
@@ -157,7 +157,7 @@ export default function TradeEditForm({ trade, onClose }) {
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-white">Executed at</label>
+            <label className="text-sm font-medium text-[var(--foreground)]">Executed at</label>
             <input
               name="executedAt"
               type="datetime-local"
@@ -167,7 +167,7 @@ export default function TradeEditForm({ trade, onClose }) {
           </div>
 
           <div className="space-y-2">
-            <label className="text-sm font-medium text-white">Closed at</label>
+            <label className="text-sm font-medium text-[var(--foreground)]">Closed at</label>
             <input
               name="closedAt"
               type="datetime-local"
@@ -177,7 +177,7 @@ export default function TradeEditForm({ trade, onClose }) {
           </div>
 
           <div className="space-y-2 sm:col-span-2">
-            <label className="text-sm font-medium text-white">Risk amount</label>
+            <label className="text-sm font-medium text-[var(--foreground)]">Risk amount</label>
             <input
               name="riskAmount"
               type="number"
@@ -189,7 +189,7 @@ export default function TradeEditForm({ trade, onClose }) {
           </div>
 
           <div className="space-y-2 sm:col-span-2">
-            <label className="text-sm font-medium text-white">Notes</label>
+            <label className="text-sm font-medium text-[var(--foreground)]">Notes</label>
             <textarea
               name="notes"
               rows={3}
@@ -213,14 +213,14 @@ export default function TradeEditForm({ trade, onClose }) {
                 {state.message}
               </p>
             ) : (
-              <p className="text-neutral-600">Changes save when you click &quot;Save changes&quot;.</p>
+              <p className="text-[var(--muted)]">Changes save when you click &quot;Save changes&quot;.</p>
             )}
           </div>
           <div className="flex items-center gap-3">
             <button
               type="button"
               onClick={onClose}
-              className="rounded-lg border border-neutral-800 px-4 py-2 text-sm font-semibold text-neutral-200 transition hover:border-neutral-600 hover:text-white"
+              className="rounded-lg border border-[var(--border)] px-4 py-2 text-sm font-semibold text-[var(--muted)] transition hover:bg-[var(--surface-hover)] hover:text-[var(--foreground)]"
             >
               Cancel
             </button>

--- a/src/app/dashboard/trades/trade-form.js
+++ b/src/app/dashboard/trades/trade-form.js
@@ -17,7 +17,7 @@ function SubmitButton() {
     <button
       type="submit"
       disabled={pending}
-      className="inline-flex items-center justify-center rounded-lg bg-white px-4 py-2 text-sm font-semibold text-neutral-900 transition hover:bg-neutral-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white disabled:cursor-not-allowed disabled:opacity-70"
+      className="inline-flex items-center justify-center rounded-lg bg-[var(--primary)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[var(--primary-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)] disabled:cursor-not-allowed disabled:opacity-70"
     >
       {pending ? "Logging…" : "Log trade"}
     </button>
@@ -28,9 +28,9 @@ function Field({ label, description, children }) {
   return (
     <div className="space-y-2">
       <div>
-        <label className="text-sm font-medium text-white">{label}</label>
+        <label className="text-sm font-medium text-[var(--foreground)]">{label}</label>
         {description ? (
-          <p className="text-xs text-neutral-500">{description}</p>
+          <p className="text-xs text-[var(--muted)]">{description}</p>
         ) : null}
       </div>
       {children}
@@ -39,7 +39,7 @@ function Field({ label, description, children }) {
 }
 
 const inputClass =
-  "w-full rounded-lg border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm text-white placeholder-neutral-600 focus:outline-none focus:ring-2 focus:ring-white/20";
+  "w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--foreground)] placeholder:text-[color:var(--muted)] focus:outline-none focus:ring-2 focus:ring-[color:rgba(24,119,242,0.35)]";
 
 export default function TradeForm() {
   const [state, formAction] = useFormState(createTradeAction, initialState);
@@ -74,10 +74,10 @@ export default function TradeForm() {
   }, [state, push]);
 
   return (
-    <section className="w-full rounded-2xl border border-neutral-900 bg-neutral-950/70 p-5 sm:p-6">
+    <section className="w-full rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-5 shadow-lg sm:p-6">
       <div className="mb-6 space-y-2">
-        <h2 className="text-lg font-semibold text-white">Log a trade</h2>
-        <p className="text-sm text-neutral-500">
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">Log a trade</h2>
+        <p className="text-sm text-[var(--muted)]">
           Capture executions as soon as they close. You can refine details later
           once analytics and attachments ship.
         </p>
@@ -192,7 +192,7 @@ export default function TradeForm() {
                 {state.message}
               </p>
             ) : (
-              <p className="text-neutral-600">
+              <p className="text-[var(--muted)]">
                 Fields marked optional can be filled in later.
               </p>
             )}

--- a/src/app/dashboard/trades/trade-row-actions.js
+++ b/src/app/dashboard/trades/trade-row-actions.js
@@ -15,16 +15,16 @@ export default function TradeRowActions({ trade, variant = "default" }) {
       ? {
           wrapper: "flex items-center gap-2",
           edit:
-            "rounded-md bg-neutral-800 px-3 py-2 text-xs font-semibold text-neutral-100",
+            "rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-xs font-semibold text-[var(--foreground)] transition hover:bg-[var(--surface-hover)]",
           remove:
-            "rounded-md bg-red-600 px-3 py-2 text-xs font-semibold text-white disabled:cursor-not-allowed disabled:opacity-70",
+            "rounded-md bg-red-600 px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-70",
         }
       : {
           wrapper: "flex items-center gap-2",
           edit:
-            "rounded border border-neutral-800 px-3 py-1 text-xs font-medium text-neutral-300 transition hover:border-neutral-600 hover:text-white",
+            "rounded border border-[var(--border)] px-3 py-1 text-xs font-medium text-[var(--muted)] transition hover:bg-[var(--surface-hover)] hover:text-[var(--foreground)]",
           remove:
-            "rounded border border-red-500/30 px-3 py-1 text-xs font-medium text-red-400 transition hover:border-red-400 hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-70",
+            "rounded border border-red-500/40 px-3 py-1 text-xs font-medium text-red-500 transition hover:border-red-500 hover:bg-red-500/10 hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-70",
         };
   const handleDelete = () => {
     const confirmed = window.confirm(
@@ -80,11 +80,11 @@ export default function TradeRowActions({ trade, variant = "default" }) {
 
       {isEditing ? (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-950/70 px-4 py-8"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(24,25,26,0.65)] px-4 py-8"
           onClick={() => setIsEditing(false)}
         >
           <div
-            className="w-full max-w-2xl rounded-2xl border border-neutral-900 bg-neutral-950 p-6 shadow-2xl"
+            className="w-full max-w-2xl rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-2xl"
             onClick={(event) => event.stopPropagation()}
           >
             <TradeEditForm trade={trade} onClose={() => setIsEditing(false)} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,8 +7,29 @@
 }
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #f0f2f5;
+  --foreground: #050505;
+  --primary: #1877f2;
+  --primary-hover: #166fe5;
+  --surface: #ffffff;
+  --surface-elevated: rgba(255, 255, 255, 0.9);
+  --surface-muted: rgba(255, 255, 255, 0.82);
+  --surface-hover: #eef3ff;
+  --border: #d0d4e4;
+  --muted: #606770;
+}
+
+[data-theme="dark"] {
+  --background: #18191a;
+  --foreground: #e4e6eb;
+  --primary: #2374e1;
+  --primary-hover: #1b4fba;
+  --surface: #242526;
+  --surface-elevated: rgba(36, 37, 38, 0.92);
+  --surface-muted: rgba(36, 37, 38, 0.86);
+  --surface-hover: #2f3032;
+  --border: #3a3b3c;
+  --muted: #b0b3b8;
 }
 
 @theme inline {
@@ -18,13 +39,6 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
   background: var(--background);
   color: var(--foreground);
@@ -32,4 +46,9 @@ body {
   max-width: 100vw;
   overflow-x: auto;
   margin: 0;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+a {
+  color: inherit;
 }

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -25,9 +25,9 @@ export const dynamic = "force-dynamic";
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en">
+    <html lang="en" data-theme="light">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-neutral-950 text-neutral-100 antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-[var(--background)] text-[var(--foreground)] antialiased`}
       >
         {children}
       </body>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,40 +1,45 @@
 import Link from "next/link";
 
+import ThemeToggle from "../components/theme-toggle";
+
 export const dynamic = "force-dynamic";
 
 export default async function HomePage() {
   return (
-    <main className="mx-auto flex min-h-screen max-w-4xl flex-col items-center justify-center gap-10 px-6 text-center">
-      <div className="space-y-4">
-        <p className="font-mono text-sm uppercase tracking-[0.35em] text-neutral-400">
-          Trading Journal
-        </p>
-        <h1 className="text-4xl font-semibold sm:text-5xl">
-          Capture every trade. Surface every insight. Level up your edge.
-        </h1>
-        <p className="text-lg text-neutral-400">
-          A focused workspace for disciplined traders. Log entries, attach
-          context, and review performance with analytics that actually help you
-          improve.
-        </p>
-      </div>
+    <div className="relative min-h-screen">
+      <ThemeToggle className="absolute right-6 top-6" />
+      <main className="mx-auto flex min-h-screen max-w-4xl flex-col items-center justify-center gap-10 px-6 text-center">
+        <div className="space-y-4">
+          <p className="font-mono text-sm uppercase tracking-[0.35em] text-[var(--muted)]">
+            Trading Journal
+          </p>
+          <h1 className="text-4xl font-semibold sm:text-5xl">
+            Capture every trade. Surface every insight. Level up your edge.
+          </h1>
+          <p className="text-lg text-[var(--muted)]">
+            A focused workspace for disciplined traders. Log entries, attach
+            context, and review performance with analytics that actually help
+            you improve.
+          </p>
+        </div>
 
-      <Link
-        href="/dashboard/trades"
-        className="rounded-full bg-white px-6 py-3 font-medium text-neutral-900 transition hover:bg-neutral-200"
-      >
-        Enter the dashboard
-      </Link>
+        <Link
+          href="/dashboard/trades"
+          className="rounded-full bg-[var(--primary)] px-6 py-3 font-medium text-white shadow-md transition hover:bg-[var(--primary-hover)]"
+        >
+          Enter the dashboard
+        </Link>
 
-      <div className="rounded-2xl border border-neutral-800 bg-neutral-900/60 p-6 text-left shadow-lg">
-        <h2 className="text-lg font-semibold">How it works</h2>
-        <ul className="mt-4 space-y-2 text-neutral-300">
-          <li>• Log trades with instrument, size, screenshots, and notes.</li>
-          <li>• Tag strategies and track win rate, R multiples, and expectancy.</li>
-          <li>• Review journal entries and analytics from any device.</li>
-          <li>• Offline-ready Progressive Web App keeps drafts safe.</li>
-        </ul>
-      </div>
-    </main>
+        <div className="w-full rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 text-left shadow-lg">
+          <h2 className="text-lg font-semibold">How it works</h2>
+          <ul className="mt-4 space-y-2 text-[var(--muted)]">
+            <li>• Log trades with instrument, size, screenshots, and notes.</li>
+            <li>• Tag strategies and track win rate, R multiples, and expectancy.</li>
+            <li>• Review journal entries and analytics from any device.</li>
+            <li>• Offline-ready Progressive Web App keeps drafts safe.</li>
+          </ul>
+        </div>
+      </main>
+    </div>
   );
 }

--- a/src/components/dashboard-shell.js
+++ b/src/components/dashboard-shell.js
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { ToastProvider } from "./toast-provider";
+import ThemeToggle from "./theme-toggle";
 
 const navItems = [
   { href: "/dashboard/trades", label: "Trades" },
@@ -24,10 +25,10 @@ export default function DashboardShell({ children }) {
           key={item.href}
           href={item.href}
           onClick={onNavigate}
-          className={`rounded-lg px-3 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white ${
+          className={`rounded-lg px-3 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)] ${
             isActive
-              ? "bg-white/10 text-white"
-              : "text-neutral-400 hover:bg-white/5 hover:text-white"
+              ? "bg-[var(--primary)] text-white shadow-sm"
+              : "text-[var(--muted)] hover:bg-[var(--surface-hover)] hover:text-[var(--foreground)]"
           }`}
         >
           {item.label}
@@ -47,13 +48,13 @@ export default function DashboardShell({ children }) {
           aria-label="Navigation"
         >
           <div
-            className="absolute inset-0 bg-neutral-950/70 backdrop-blur-sm"
+            className="absolute inset-0 bg-[rgba(24,25,26,0.65)] backdrop-blur-sm"
             onClick={closeMobileNav}
             aria-hidden="true"
           />
-          <div className="relative flex h-full w-64 flex-col border-r border-neutral-900 bg-neutral-950 p-6 shadow-xl">
+          <div className="relative flex h-full w-64 flex-col gap-6 border-r border-[var(--border)] bg-[var(--surface)] p-6 shadow-xl">
             <div>
-              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-neutral-500">
+              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--muted)]">
                 Journal
               </p>
               <h2 className="mt-2 text-xl font-semibold">Control Center</h2>
@@ -61,13 +62,14 @@ export default function DashboardShell({ children }) {
             <button
               type="button"
               onClick={closeMobileNav}
-              className="absolute right-5 top-5 rounded-md border border-neutral-800 px-2 py-1 text-xs font-medium text-neutral-300 transition hover:border-neutral-600 hover:text-white"
+              className="absolute right-5 top-5 rounded-md border border-[var(--border)] px-2 py-1 text-xs font-medium text-[var(--muted)] transition hover:bg-[var(--surface-hover)] hover:text-[var(--foreground)]"
             >
               Close
             </button>
+            <ThemeToggle className="w-full justify-between" />
             <nav
               id="mobile-dashboard-navigation"
-              className="mt-8 flex flex-col gap-1"
+              className="flex flex-col gap-1"
               aria-label="Mobile navigation"
             >
               {renderNavItems(closeMobileNav)}
@@ -75,10 +77,10 @@ export default function DashboardShell({ children }) {
           </div>
         </div>
       )}
-      <div className="flex min-h-screen w-full bg-neutral-950 text-neutral-100">
-        <aside className="hidden w-60 border-r border-neutral-900 bg-neutral-950/60 p-6 sm:flex sm:flex-col">
+      <div className="flex min-h-screen w-full bg-[var(--background)] text-[var(--foreground)]">
+        <aside className="hidden w-60 border-r border-[var(--border)] bg-[var(--surface-muted)] p-6 sm:flex sm:flex-col">
           <div>
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-neutral-500">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[var(--muted)]">
               Journal
             </p>
             <h2 className="mt-2 text-xl font-semibold">Control Center</h2>
@@ -90,27 +92,31 @@ export default function DashboardShell({ children }) {
         </aside>
 
         <div className="flex flex-1 flex-col">
-          <header className="flex h-16 items-center justify-between border-b border-neutral-900 bg-neutral-950/80 px-4 backdrop-blur">
+          <header className="flex h-16 items-center justify-between border-b border-[var(--border)] bg-[var(--surface-elevated)] px-4 backdrop-blur">
             <div className="flex items-center gap-2">
               <button
                 type="button"
                 onClick={() => setIsMobileNavOpen(true)}
-                className="inline-flex items-center rounded-md border border-neutral-800 px-3 py-1.5 text-xs font-medium uppercase tracking-[0.2em] text-neutral-300 transition hover:border-neutral-600 hover:text-white sm:hidden"
+                className="inline-flex items-center rounded-md border border-[var(--border)] px-3 py-1.5 text-xs font-medium uppercase tracking-[0.2em] text-[var(--muted)] transition hover:bg-[var(--surface-hover)] hover:text-[var(--foreground)] sm:hidden"
                 aria-expanded={isMobileNavOpen}
                 aria-controls="mobile-dashboard-navigation"
               >
                 Menu
               </button>
-              <span className="text-sm font-semibold uppercase tracking-[0.35em] text-neutral-500">
+              <span className="text-sm font-semibold uppercase tracking-[0.35em] text-[var(--muted)]">
                 Trading Journal
               </span>
             </div>
-            <Link
-              href="/"
-              className="rounded-full border border-neutral-800 px-3 py-1 text-xs font-medium text-neutral-300 transition hover:border-neutral-600 hover:text-white"
-            >
-              Exit
-            </Link>
+            <div className="flex items-center gap-3">
+              <ThemeToggle className="sm:hidden" />
+              <ThemeToggle className="hidden sm:flex" />
+              <Link
+                href="/"
+                className="rounded-full border border-[var(--border)] px-3 py-1 text-xs font-medium text-[var(--muted)] transition hover:bg-[var(--surface-hover)] hover:text-[var(--foreground)]"
+              >
+                Exit
+              </Link>
+            </div>
           </header>
           <main className="flex-1 px-4 py-8 sm:px-8">{children}</main>
         </div>

--- a/src/components/theme-toggle.js
+++ b/src/components/theme-toggle.js
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const THEME_KEY = "trading-journal-theme";
+
+const getPreferredTheme = () => {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  const stored = window.localStorage.getItem(THEME_KEY);
+  if (stored === "light" || stored === "dark") {
+    return stored;
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+};
+
+export default function ThemeToggle({ className = "" }) {
+  const [theme, setTheme] = useState("light");
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    const preferred = getPreferredTheme();
+    document.documentElement.setAttribute("data-theme", preferred);
+    setTheme(preferred);
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isMounted) {
+      return;
+    }
+
+    window.localStorage.setItem(THEME_KEY, theme);
+  }, [isMounted, theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => {
+      const next = prev === "dark" ? "light" : "dark";
+      document.documentElement.setAttribute("data-theme", next);
+      return next;
+    });
+  };
+
+  const label = theme === "dark" ? "Switch to day mode" : "Switch to night mode";
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      className={`flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--surface)] px-4 py-2 text-sm font-medium text-[var(--foreground)] shadow-sm transition hover:bg-[var(--surface-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)] ${className}`}
+      aria-pressed={theme === "dark"}
+      aria-label={label}
+    >
+      <span
+        className="inline-flex h-2.5 w-2.5 rounded-full"
+        style={{ backgroundColor: theme === "dark" ? "#2374e1" : "#1877f2" }}
+        aria-hidden="true"
+      />
+      <span className="whitespace-nowrap text-xs sm:text-sm">
+        {isMounted ? (theme === "dark" ? "Night mode" : "Day mode") : "Theme"}
+      </span>
+    </button>
+  );
+}

--- a/src/components/toast-provider.js
+++ b/src/components/toast-provider.js
@@ -90,7 +90,7 @@ function ToastItem({ toast, onDismiss }) {
   }, [toast, onDismiss]);
 
   const variantStyles = {
-    default: "border-neutral-800 bg-neutral-900 text-neutral-100",
+    default: "border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)]",
     success: "border-emerald-500/40 bg-emerald-500/10 text-emerald-200",
     error: "border-red-500/40 bg-red-500/10 text-red-200",
   };
@@ -106,13 +106,13 @@ function ToastItem({ toast, onDismiss }) {
         <div className="space-y-1">
           {toast.title ? <p className="text-sm font-semibold">{toast.title}</p> : null}
           {toast.description ? (
-            <p className="text-sm text-neutral-400">{toast.description}</p>
+            <p className="text-sm text-[var(--muted)]">{toast.description}</p>
           ) : null}
         </div>
         <button
           type="button"
           onClick={() => onDismiss(toast.id)}
-          className="text-xs uppercase tracking-wide text-neutral-500 transition hover:text-neutral-200"
+          className="text-xs uppercase tracking-wide text-[var(--muted)] transition hover:text-[var(--foreground)]"
         >
           Close
         </button>


### PR DESCRIPTION
## Summary
- add a theme toggle that persists preference and drive a Facebook-inspired palette via CSS variables
- restyle the landing layout, dashboard chrome, and toast notifications to use the shared theme tokens
- update trades, analytics, journal, and settings pages to adopt the new light/night colors and accents

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1cedd21fc8329aea6f97cbcc0cef1